### PR TITLE
Add EC2 bootstrap scripts and HTTPS cleanup

### DIFF
--- a/MAINTENANCE_PLAN.md
+++ b/MAINTENANCE_PLAN.md
@@ -1,0 +1,151 @@
+# WPGSA Maintenance Plan
+
+This document turns the current maintenance work into a concrete sequence with decision points.
+
+## Current State
+
+- Web app: Sinatra app running as a native process
+- Analysis: invoked via `docker run` from the web process
+- Data: one bundled mouse reference network in `data/`
+- Hosting: AWS EC2
+- Immediate web fix: asset URL generation was fixed on branch `fix-css-layout-issues`
+
+Relevant code:
+
+- App URL helper: `app.rb`
+- Analysis launcher: `lib/wpgsa/docker.rb`
+- Network initialization: `lib/tasks/init.rake`
+
+## Phase 0: Production Stabilization
+
+Goal: restore correct HTTPS page rendering and remove obvious mixed-content risks.
+
+Checklist:
+
+- Deploy branch `fix-css-layout-issues`
+- Confirm the reverse proxy or load balancer forwards `X-Forwarded-Proto=https`
+- Verify these pages load with no blocked assets:
+  - `/`
+  - `/download`
+  - `/result?uuid=example`
+  - `/result/heatmap?uuid=example`
+- Test upload flow and result rendering
+- Check browser console for mixed-content and JavaScript errors
+- Merge the remaining external-link HTTPS cleanup in templates
+
+Exit criteria:
+
+- CSS/JS assets are loaded over HTTPS
+- Layout renders correctly on home, result, and heatmap pages
+- Upload and analysis still work
+
+## Phase 1: EC2 Migration to Amazon Linux 2023
+
+Goal: move off the old instance with minimal application change.
+
+Strategy:
+
+- Build a new host in parallel
+- Reproduce the current runtime first
+- Cut over only after validation
+
+Inventory on the current host:
+
+- AMI and OS version
+- Ruby version and Bundler version
+- App process manager (`systemd`, init script, or other)
+- Front proxy (`nginx`, `apache`, or ALB only)
+- Docker version and image pull behavior
+- TLS/certificate handling
+- Log file paths
+- Disk layout and backup points
+- Cron jobs or ad hoc scripts
+
+Build on the new host:
+
+- Launch a fresh EC2 instance on Amazon Linux 2023
+- Install Ruby runtime dependencies
+- Install Docker
+- Create app directory and service user
+- Deploy app code and config
+- Copy the reference network and any persistent `public/data` you need to keep
+- Recreate the app service definition
+- Recreate proxy/TLS configuration
+- Run smoke tests before cutover
+
+Cutover:
+
+- Lower DNS TTL in advance
+- Switch DNS or load balancer target
+- Monitor logs and rollback window
+
+Exit criteria:
+
+- New AL2023 instance serves production traffic
+- Analysis jobs still execute successfully via Docker
+- Restart/runbook is documented
+
+## Phase 2: ECS Feasibility Spike
+
+Goal: decide whether ECS is worth the refactor cost.
+
+Current blocker:
+
+- The app shells out to `docker run`, which is not a clean fit for ECS Fargate
+
+Options:
+
+- Keep EC2: lowest risk, fastest
+- ECS on EC2: possible, but operationally less compelling
+- ECS Fargate: requires refactor
+
+Recommended spike:
+
+- Build one container image that contains both the Sinatra app and the analysis code
+- Replace `docker run ... wpgsa` with a direct local process invocation inside the same container
+- Externalize `config.yaml` and reference network path
+- Test whether CPU, memory, temp disk, and runtime are acceptable under a single-task model
+
+Decision gate:
+
+- If the single-container design works cleanly, proceed toward ECS/Fargate
+- If not, keep production on EC2 and revisit architecture later
+
+## Phase 3: Reference Network Refresh
+
+Goal: replace the outdated mouse-only network with a versioned network built from newer data, likely using ChIP-Atlas target-gene resources.
+
+Why this is separate:
+
+- This changes scientific inputs and output interpretation
+- It needs validation, not just deployment
+
+Work items:
+
+- Define the source dataset and versioning scheme
+- Map ChIP-Atlas target-gene output to the current network columns:
+  - `TF_Uniprot`
+  - `TF_egSym`
+  - `TargetSym`
+  - `Target_geneID`
+  - `positive No.`
+  - `experiment No.`
+- Generate a mouse replacement first
+- Add support for selecting network by species and version in config
+- Add at least one human network if required by the product direction
+- Benchmark old versus new results on known datasets
+- Document provenance and update cadence
+
+Exit criteria:
+
+- New network file is reproducible and versioned
+- Results are validated on benchmark inputs
+- App can switch networks without code edits
+
+## Immediate Next Actions
+
+1. Finish and merge the HTTPS/layout fixes.
+2. Capture the current production instance inventory.
+3. Build the replacement AL2023 EC2 host.
+4. Only after stable cutover, start the ECS spike.
+5. Run the network-refresh project as a separately validated release.

--- a/script/WPGSA_EC2_SETUP.md
+++ b/script/WPGSA_EC2_SETUP.md
@@ -1,0 +1,73 @@
+# EC2 Launch Script
+
+These scripts create a fresh Amazon Linux 2023 EC2 instance and bootstrap it into a running `wpgsa.org` host.
+
+Files:
+
+- `script/launch-wpgsa-ec2.sh`: run this from your local machine
+- `script/bootstrap-wpgsa-instance.sh`: runs on the EC2 instance via user data
+
+## What It Sets Up
+
+- Amazon Linux 2023 instance
+- Security group for `22`, `80`, `443`
+- `nginx` reverse proxy
+- `docker`
+- Ruby + Bundler
+- app checkout from `https://github.com/inutano/wpgsa.org.git`
+- branch `master`
+- `systemd` service named `wpgsa`
+- app config pointing at `data/merged_mouse_150904_trim.network`
+- Docker image pull for `inutano/wpgsa:0.5.2`
+
+## Assumptions
+
+- You already have AWS credentials for the target account.
+- You already have an EC2 key pair in the target region.
+- The GitHub repo is publicly cloneable.
+- The Docker image `inutano/wpgsa:0.5.2` is pullable from the instance.
+- You either use an existing Elastic IP or are fine with a new public IP first.
+
+## Required Environment Variables
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN` if you use temporary credentials
+- `AWS_REGION` or `AWS_DEFAULT_REGION`
+- `KEY_NAME`
+
+## Optional Environment Variables
+
+- `INSTANCE_TYPE`
+- `DOMAIN_NAME`
+- `APP_BRANCH`
+- `EIP_ALLOCATION_ID`
+- `SUBNET_ID`
+- `VPC_ID`
+- `SECURITY_GROUP_ID`
+- `SSH_CIDR`
+- `ROOT_VOLUME_SIZE`
+- `INSTANCE_PROFILE_NAME`
+- `ENABLE_TLS=true`
+- `LETSENCRYPT_EMAIL=you@example.org`
+
+## Example
+
+```bash
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...
+export AWS_REGION=us-east-1
+export KEY_NAME=my-ec2-key
+export EIP_ALLOCATION_ID=eipalloc-0123456789abcdef0
+export DOMAIN_NAME=wpgsa.org
+export INSTANCE_TYPE=t3.small
+
+bash script/launch-wpgsa-ec2.sh
+```
+
+## Notes
+
+- If `ENABLE_TLS=true`, the instance bootstrap will try `certbot --nginx`.
+- TLS only succeeds after the domain resolves to the new instance.
+- If the certbot packages are unavailable in the region image mirror, bootstrap falls back to plain HTTP and leaves the app up.

--- a/script/bootstrap-wpgsa-instance.sh
+++ b/script/bootstrap-wpgsa-instance.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/wpgsa.org}"
+APP_USER="${APP_USER:-wpgsa}"
+APP_GROUP="${APP_GROUP:-wpgsa}"
+APP_BRANCH="${APP_BRANCH:-master}"
+APP_REPO="${APP_REPO:-https://github.com/inutano/wpgsa.org.git}"
+DOMAIN_NAME="${DOMAIN_NAME:-wpgsa.org}"
+APP_PORT="${APP_PORT:-9292}"
+APP_HOST="${APP_HOST:-127.0.0.1}"
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
+ENABLE_TLS="${ENABLE_TLS:-false}"
+
+log() {
+  printf '[bootstrap] %s\n' "$1"
+}
+
+retry() {
+  local n=0
+  local max=10
+  local delay=15
+  while true; do
+    if "$@"; then
+      return 0
+    fi
+    n=$((n + 1))
+    if [ "$n" -ge "$max" ]; then
+      return 1
+    fi
+    sleep "$delay"
+  done
+}
+
+install_packages() {
+  log "installing OS packages"
+  retry dnf makecache
+  retry dnf install -y \
+    git \
+    nginx \
+    docker \
+    ruby \
+    ruby-devel \
+    rubygems \
+    gcc \
+    gcc-c++ \
+    make \
+    patch \
+    openssl-devel \
+    zlib-devel \
+    libffi-devel \
+    redhat-rpm-config \
+    tar \
+    gzip \
+    which \
+    procps-ng \
+    jq \
+    findutils \
+    shadow-utils
+}
+
+create_app_user() {
+  if ! id -u "$APP_USER" >/dev/null 2>&1; then
+    useradd --system --create-home --home-dir /home/"$APP_USER" --shell /bin/bash "$APP_USER"
+  fi
+}
+
+install_bundler() {
+  log "installing bundler"
+  gem install bundler -N
+}
+
+checkout_app() {
+  log "checking out app code"
+  mkdir -p "$APP_DIR"
+  if [ ! -d "$APP_DIR/.git" ]; then
+    git clone "$APP_REPO" "$APP_DIR"
+  fi
+  git -C "$APP_DIR" fetch --all --tags
+  git -C "$APP_DIR" checkout "$APP_BRANCH"
+  git -C "$APP_DIR" pull --ff-only origin "$APP_BRANCH"
+  chown -R "$APP_USER":"$APP_GROUP" "$APP_DIR"
+}
+
+configure_app() {
+  log "configuring app"
+  cat > "$APP_DIR/config.yaml" <<EOF
+workdir: "/tmp/wpgsa"
+network_file_path: "$APP_DIR/data/merged_mouse_150904_trim.network"
+EOF
+
+  mkdir -p /tmp/wpgsa
+  chmod 0777 /tmp/wpgsa
+  mkdir -p "$APP_DIR/public/data"
+  chown -R "$APP_USER":"$APP_GROUP" /tmp/wpgsa "$APP_DIR/public/data"
+}
+
+bundle_install() {
+  log "installing Ruby gems"
+  su - "$APP_USER" -c "cd '$APP_DIR' && bundle config set --local path vendor/bundle && bundle install"
+}
+
+configure_systemd() {
+  log "writing systemd unit"
+  cat > /etc/systemd/system/wpgsa.service <<EOF
+[Unit]
+Description=wPGSA Sinatra application
+After=network.target docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+User=$APP_USER
+Group=$APP_GROUP
+WorkingDirectory=$APP_DIR
+Environment=RACK_ENV=production
+ExecStart=/usr/local/bin/bundle exec rackup --host $APP_HOST --port $APP_PORT
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  systemctl daemon-reload
+  systemctl enable docker
+  systemctl restart docker
+  systemctl enable wpgsa
+  systemctl restart wpgsa
+}
+
+configure_nginx() {
+  log "writing nginx config"
+  cat > /etc/nginx/conf.d/wpgsa.conf <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    server_name $DOMAIN_NAME;
+
+    client_max_body_size 100m;
+
+    location / {
+        proxy_pass http://$APP_HOST:$APP_PORT;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+        proxy_set_header X-Forwarded-Host \$host;
+        proxy_set_header X-Forwarded-Port \$server_port;
+    }
+}
+EOF
+
+  rm -f /etc/nginx/conf.d/default.conf
+  nginx -t
+  systemctl enable nginx
+  systemctl restart nginx
+}
+
+pull_algorithm_image() {
+  log "pulling algorithm container image"
+  retry docker pull inutano/wpgsa:0.5.2
+}
+
+enable_tls_if_requested() {
+  if [ "$ENABLE_TLS" != "true" ]; then
+    log "TLS bootstrap skipped"
+    return 0
+  fi
+
+  if [ -z "$LETSENCRYPT_EMAIL" ]; then
+    log "ENABLE_TLS=true but LETSENCRYPT_EMAIL is empty; skipping TLS"
+    return 0
+  fi
+
+  if ! dnf install -y certbot python3-certbot-nginx; then
+    log "certbot packages unavailable; skipping TLS"
+    return 0
+  fi
+
+  log "requesting Let's Encrypt certificate"
+  certbot --nginx \
+    --non-interactive \
+    --agree-tos \
+    --email "$LETSENCRYPT_EMAIL" \
+    -d "$DOMAIN_NAME" \
+    --redirect || log "certbot failed; app remains on HTTP"
+}
+
+show_status() {
+  log "systemd status summary"
+  systemctl --no-pager --full status wpgsa || true
+  systemctl --no-pager --full status nginx || true
+  systemctl --no-pager --full status docker || true
+}
+
+main() {
+  install_packages
+  create_app_user
+  install_bundler
+  checkout_app
+  configure_app
+  bundle_install
+  configure_systemd
+  configure_nginx
+  pull_algorithm_image
+  enable_tls_if_requested
+  show_status
+  log "bootstrap finished"
+}
+
+main "$@"

--- a/script/launch-wpgsa-ec2.sh
+++ b/script/launch-wpgsa-ec2.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BOOTSTRAP_SCRIPT="$SCRIPT_DIR/bootstrap-wpgsa-instance.sh"
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+INSTANCE_TYPE="${INSTANCE_TYPE:-t3.small}"
+ARCH="${ARCH:-x86_64}"
+AMI_PARAM="${AMI_PARAM:-al2023-ami-kernel-default-${ARCH}}"
+KEY_NAME="${KEY_NAME:-}"
+DOMAIN_NAME="${DOMAIN_NAME:-wpgsa.org}"
+HOSTNAME_TAG="${HOSTNAME_TAG:-wpgsa-org}"
+APP_BRANCH="${APP_BRANCH:-master}"
+APP_REPO="${APP_REPO:-https://github.com/inutano/wpgsa.org.git}"
+EIP_ALLOCATION_ID="${EIP_ALLOCATION_ID:-}"
+SUBNET_ID="${SUBNET_ID:-}"
+VPC_ID="${VPC_ID:-}"
+SECURITY_GROUP_ID="${SECURITY_GROUP_ID:-}"
+SECURITY_GROUP_NAME="${SECURITY_GROUP_NAME:-wpgsa-web}"
+SSH_CIDR="${SSH_CIDR:-0.0.0.0/0}"
+ROOT_VOLUME_SIZE="${ROOT_VOLUME_SIZE:-30}"
+INSTANCE_PROFILE_NAME="${INSTANCE_PROFILE_NAME:-}"
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
+ENABLE_TLS="${ENABLE_TLS:-false}"
+TAG_SPEC="ResourceType=instance,Tags=[{Key=Name,Value=${HOSTNAME_TAG}},{Key=Project,Value=wpgsa.org}]"
+
+die() {
+  printf 'error: %s\n' "$1" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+require_env() {
+  [ -n "${!1:-}" ] || die "missing required variable: $1"
+}
+
+ensure_aws_auth() {
+  aws sts get-caller-identity --region "$REGION" >/dev/null
+}
+
+default_vpc() {
+  aws ec2 describe-vpcs \
+    --region "$REGION" \
+    --filters Name=isDefault,Values=true \
+    --query 'Vpcs[0].VpcId' \
+    --output text
+}
+
+default_subnet() {
+  local vpc_id="$1"
+  aws ec2 describe-subnets \
+    --region "$REGION" \
+    --filters Name=vpc-id,Values="$vpc_id" Name=default-for-az,Values=true \
+    --query 'Subnets[0].SubnetId' \
+    --output text
+}
+
+ensure_security_group() {
+  local vpc_id="$1"
+  local sg_id
+
+  sg_id="$(aws ec2 describe-security-groups \
+    --region "$REGION" \
+    --filters Name=vpc-id,Values="$vpc_id" Name=group-name,Values="$SECURITY_GROUP_NAME" \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text)"
+
+  if [ "$sg_id" = "None" ] || [ -z "$sg_id" ]; then
+    sg_id="$(aws ec2 create-security-group \
+      --region "$REGION" \
+      --group-name "$SECURITY_GROUP_NAME" \
+      --description "wpgsa.org web access" \
+      --vpc-id "$vpc_id" \
+      --query 'GroupId' \
+      --output text)"
+
+    aws ec2 authorize-security-group-ingress \
+      --region "$REGION" \
+      --group-id "$sg_id" \
+      --ip-permissions \
+      "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=${SSH_CIDR},Description=SSH}]" \
+      "IpProtocol=tcp,FromPort=80,ToPort=80,IpRanges=[{CidrIp=0.0.0.0/0,Description=HTTP}]" \
+      "IpProtocol=tcp,FromPort=443,ToPort=443,IpRanges=[{CidrIp=0.0.0.0/0,Description=HTTPS}]"
+  fi
+
+  printf '%s\n' "$sg_id"
+}
+
+render_user_data() {
+  local tmpfile
+  tmpfile="$(mktemp)"
+  cat > "$tmpfile" <<EOF
+#!/bin/bash
+set -euo pipefail
+
+export APP_BRANCH='${APP_BRANCH}'
+export APP_REPO='${APP_REPO}'
+export DOMAIN_NAME='${DOMAIN_NAME}'
+export ENABLE_TLS='${ENABLE_TLS}'
+export LETSENCRYPT_EMAIL='${LETSENCRYPT_EMAIL}'
+
+cat >/root/bootstrap-wpgsa-instance.sh <<'BOOTSTRAP'
+$(cat "$BOOTSTRAP_SCRIPT")
+BOOTSTRAP
+
+chmod +x /root/bootstrap-wpgsa-instance.sh
+/root/bootstrap-wpgsa-instance.sh > /var/log/wpgsa-bootstrap.log 2>&1
+EOF
+  printf '%s\n' "$tmpfile"
+}
+
+launch_instance() {
+  local subnet_id="$1"
+  local sg_id="$2"
+  local user_data_file="$3"
+  local iam_args=()
+
+  if [ -n "$INSTANCE_PROFILE_NAME" ]; then
+    iam_args=(--iam-instance-profile "Name=${INSTANCE_PROFILE_NAME}")
+  fi
+
+  aws ec2 run-instances \
+    --region "$REGION" \
+    --image-id "resolve:ssm:/aws/service/ami-amazon-linux-latest/${AMI_PARAM}" \
+    --instance-type "$INSTANCE_TYPE" \
+    --subnet-id "$subnet_id" \
+    --security-group-ids "$sg_id" \
+    --key-name "$KEY_NAME" \
+    --associate-public-ip-address \
+    --block-device-mappings "[{\"DeviceName\":\"/dev/xvda\",\"Ebs\":{\"VolumeSize\":${ROOT_VOLUME_SIZE},\"VolumeType\":\"gp3\",\"DeleteOnTermination\":true}}]" \
+    --tag-specifications "$TAG_SPEC" \
+    --user-data "file://${user_data_file}" \
+    "${iam_args[@]}" \
+    --query 'Instances[0].InstanceId' \
+    --output text
+}
+
+associate_eip() {
+  local instance_id="$1"
+  [ -n "$EIP_ALLOCATION_ID" ] || return 0
+
+  aws ec2 associate-address \
+    --region "$REGION" \
+    --instance-id "$instance_id" \
+    --allocation-id "$EIP_ALLOCATION_ID" \
+    --allow-reassociation >/dev/null
+}
+
+instance_public_ip() {
+  local instance_id="$1"
+  aws ec2 describe-instances \
+    --region "$REGION" \
+    --instance-ids "$instance_id" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text
+}
+
+instance_public_dns() {
+  local instance_id="$1"
+  aws ec2 describe-instances \
+    --region "$REGION" \
+    --instance-ids "$instance_id" \
+    --query 'Reservations[0].Instances[0].PublicDnsName' \
+    --output text
+}
+
+print_summary() {
+  local instance_id="$1"
+  local sg_id="$2"
+  local ip dns
+
+  ip="$(instance_public_ip "$instance_id")"
+  dns="$(instance_public_dns "$instance_id")"
+
+  cat <<EOF
+
+Launch complete.
+
+Region:          $REGION
+Instance ID:     $instance_id
+Security Group:  $sg_id
+Public IP:       $ip
+Public DNS:      $dns
+Domain target:   $DOMAIN_NAME
+Branch:          $APP_BRANCH
+
+Next checks:
+  1. Wait a few minutes for cloud-init to finish.
+  2. SSH in and inspect: sudo tail -f /var/log/wpgsa-bootstrap.log
+  3. Inspect services: sudo systemctl status wpgsa nginx docker
+  4. If you used an Elastic IP, point wpgsa.org DNS to it if not already attached.
+  5. If ENABLE_TLS=true, verify certbot succeeded after DNS resolves to this host.
+
+EOF
+}
+
+main() {
+  need_cmd aws
+  require_env KEY_NAME
+  [ -f "$BOOTSTRAP_SCRIPT" ] || die "bootstrap script not found: $BOOTSTRAP_SCRIPT"
+  ensure_aws_auth
+
+  if [ -z "$VPC_ID" ]; then
+    VPC_ID="$(default_vpc)"
+  fi
+  [ "$VPC_ID" != "None" ] || die "could not resolve a VPC_ID; set VPC_ID explicitly"
+
+  if [ -z "$SUBNET_ID" ]; then
+    SUBNET_ID="$(default_subnet "$VPC_ID")"
+  fi
+  [ "$SUBNET_ID" != "None" ] || die "could not resolve a SUBNET_ID; set SUBNET_ID explicitly"
+
+  if [ -z "$SECURITY_GROUP_ID" ]; then
+    SECURITY_GROUP_ID="$(ensure_security_group "$VPC_ID")"
+  fi
+
+  local user_data_file instance_id
+  user_data_file="$(render_user_data)"
+  trap 'rm -f "$user_data_file"' EXIT
+
+  instance_id="$(launch_instance "$SUBNET_ID" "$SECURITY_GROUP_ID" "$user_data_file")"
+
+  aws ec2 wait instance-running --region "$REGION" --instance-ids "$instance_id"
+  associate_eip "$instance_id"
+  aws ec2 wait instance-status-ok --region "$REGION" --instance-ids "$instance_id"
+
+  print_summary "$instance_id" "$SECURITY_GROUP_ID"
+}
+
+main "$@"

--- a/script/server-inventory.sh
+++ b/script/server-inventory.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+section() {
+  printf '\n== %s ==\n' "$1"
+}
+
+cmd() {
+  local label="$1"
+  shift
+
+  printf '\n$ %s\n' "$label"
+  if "$@"; then
+    :
+  else
+    printf '[command failed]\n'
+  fi
+}
+
+section "Timestamp"
+cmd "date -Is" date -Is
+
+section "Host"
+cmd "hostnamectl" hostnamectl
+cmd "uname -a" uname -a
+cmd "cat /etc/os-release" cat /etc/os-release
+
+section "Runtime"
+cmd "ruby -v" ruby -v
+cmd "bundle -v" bundle -v
+cmd "gem env home" gem env home
+cmd "which ruby" which ruby
+cmd "which bundle" which bundle
+
+section "App Process"
+cmd "ps -ef | grep -E 'ruby|rackup|puma|unicorn|passenger|sinatra' | grep -v grep" sh -c "ps -ef | grep -E 'ruby|rackup|puma|unicorn|passenger|sinatra' | grep -v grep"
+cmd "systemctl list-units --type=service --all | grep -Ei 'wpgsa|ruby|rack|puma|unicorn|nginx|httpd|apache|docker'" sh -c "systemctl list-units --type=service --all | grep -Ei 'wpgsa|ruby|rack|puma|unicorn|nginx|httpd|apache|docker' || true"
+cmd "systemctl list-unit-files | grep -Ei 'wpgsa|ruby|rack|puma|unicorn|nginx|httpd|apache|docker'" sh -c "systemctl list-unit-files | grep -Ei 'wpgsa|ruby|rack|puma|unicorn|nginx|httpd|apache|docker' || true"
+
+section "Web Proxy"
+cmd "nginx -v" nginx -v
+cmd "httpd -v" httpd -v
+cmd "apachectl -v" apachectl -v
+cmd "ls /etc/nginx" ls -la /etc/nginx
+cmd "find /etc/nginx -maxdepth 2 -type f" find /etc/nginx -maxdepth 2 -type f
+cmd "find /etc/httpd -maxdepth 3 -type f" find /etc/httpd -maxdepth 3 -type f
+
+section "TLS"
+cmd "certbot --version" certbot --version
+cmd "find /etc/letsencrypt -maxdepth 3 -type f" find /etc/letsencrypt -maxdepth 3 -type f
+
+section "Docker"
+cmd "docker --version" docker --version
+cmd "docker info --format '{{json .}}'" docker info --format "{{json .}}"
+cmd "docker images" docker images
+cmd "docker ps -a" docker ps -a
+
+section "Filesystem"
+cmd "df -h" df -h
+cmd "lsblk" lsblk
+cmd "mount" mount
+cmd "ls -la /tmp" ls -la /tmp
+
+section "Application Files"
+cmd "pwd" pwd
+cmd "find /home -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\)" sh -c "find /home -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\) 2>/dev/null || true"
+cmd "find /opt -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\)" sh -c "find /opt -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\) 2>/dev/null || true"
+cmd "find /srv -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\)" sh -c "find /srv -maxdepth 3 -type d \\( -name 'wpgsa.org' -o -name 'wpgsa' \\) 2>/dev/null || true"
+
+section "Scheduled Jobs"
+cmd "crontab -l" crontab -l
+cmd "find /etc/cron* -maxdepth 2 -type f" find /etc/cron.d /etc/cron.daily /etc/cron.hourly /etc/cron.monthly /etc/cron.weekly -maxdepth 2 -type f
+
+section "Networking"
+cmd "ss -ltnp" ss -ltnp
+cmd "ip addr" ip addr
+cmd "ip route" ip route
+
+section "Recent Logs"
+cmd "journalctl -n 200 --no-pager" journalctl -n 200 --no-pager
+cmd "journalctl -u docker -n 100 --no-pager" journalctl -u docker -n 100 --no-pager
+

--- a/views/download.haml
+++ b/views/download.haml
@@ -83,7 +83,7 @@
                       %li includeFeature: peak include the gene (impractical)
                     %li distancetoFeature: distance between the start of the peak and the TSS of the nearest gene
                 %p
-                  %a.btn.btn-primary.downloadLink{ href: "http://web.ims.riken.jp/en/paper_data/wPGSA_ChIPpeak_detailed_info.tar.bz2" } Download TF binding peak data
+                  %a.btn.btn-primary.downloadLink{ href: "https://web.ims.riken.jp/en/paper_data/wPGSA_ChIPpeak_detailed_info.tar.bz2" } Download TF binding peak data
 
     .container
       .row
@@ -103,10 +103,10 @@
           .col-md-4.col-md-offset-4
             %ul.list-inline
               %li
-                %a{ href: "http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                   %img{ src: "/images/logo/riken-logo.gif", width: 100 }
               %li
-                %a{ href: "http://dbcls.rois.ac.jp", target: "_blank" }
+                %a{ href: "https://dbcls.rois.ac.jp", target: "_blank" }
                   %img{ src: "/images/logo/dbcls_logo.png", width: 100 }
         .row
           .col-md-6.col-md-offset-3

--- a/views/heatmap.haml
+++ b/views/heatmap.haml
@@ -102,10 +102,10 @@
           .col-md-4.col-md-offset-4
             %ul.list-inline
               %li
-                %a{ href: "http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                   %img{ src: "/images/logo/riken-logo.gif", width: 100 }
               %li
-                %a{ href: "http://dbcls.rois.ac.jp", target: "_blank" }
+                %a{ href: "https://dbcls.rois.ac.jp", target: "_blank" }
                   %img{ src: "/images/logo/dbcls_logo.png", width: 100 }
         .row
           .col-md-6.col-md-offset-3

--- a/views/index.haml
+++ b/views/index.haml
@@ -86,7 +86,7 @@
                   Log fold change data should be prepared in an ASCII tab delimited text file. It is organized as follows.
                 %p
                   To create and edit the log fold change file, use a text editor or Excel. When you use Excel, be aware of a problem as described in
-                  %a{ href: "http://www.ncbi.nlm.nih.gov/pubmed/15214961" }
+                  %a{ href: "https://www.ncbi.nlm.nih.gov/pubmed/15214961" }
                     Zeeberg et al 2004
                   \.
                 %p
@@ -150,13 +150,13 @@
               .panel-input
                 %p
                   wPGSA is being developed by the
-                  %a{ href: " http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                  %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                     Laboratory for Disease Systems Modeling
                   at the
-                  %a{ href: " http://www.ims.riken.jp/english/", target: "_blank" }
+                  %a{ href: "https://www.ims.riken.jp/english/", target: "_blank" }
                     RIKEN-IMS
                   and
-                  %a{ href: "http://dbcls.rois.ac.jp/en", target: "_blank" }
+                  %a{ href: "https://dbcls.rois.ac.jp/en", target: "_blank" }
                     Database Center for Life Science
                   \. This work was supported by JSPS KAKENHI Grant Number 15K21631 and 15KT0147.
 
@@ -178,10 +178,10 @@
           .col-md-4.col-md-offset-4
             %ul.list-inline
               %li
-                %a{ href: "http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                   %img{ src: "/images/logo/riken-logo.gif", width: 100 }
               %li
-                %a{ href: "http://dbcls.rois.ac.jp", target: "_blank" }
+                %a{ href: "https://dbcls.rois.ac.jp", target: "_blank" }
                   %img{ src: "/images/logo/dbcls_logo.png", width: 100 }
         .row
           .col-md-6.col-md-offset-3

--- a/views/not_found.haml
+++ b/views/not_found.haml
@@ -58,10 +58,10 @@
           .col-md-4.col-md-offset-4
             %ul.list-inline
               %li
-                %a{ href: "http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                   %img{ src: "/images/logo/riken-logo.gif", width: 100 }
               %li
-                %a{ href: "http://dbcls.rois.ac.jp", target: "_blank" }
+                %a{ href: "https://dbcls.rois.ac.jp", target: "_blank" }
                   %img{ src: "/images/logo/dbcls_logo.png", width: 100 }
         .row
           .col-md-6.col-md-offset-3

--- a/views/result.haml
+++ b/views/result.haml
@@ -96,7 +96,7 @@
                     %dt TF:
                     %dd
                       The Uniprot entry name of a transcription factor. Click the TF name to look up the TF information in
-                      %a{ href: "http://www.uniprot.org", target: "_blank" }
+                      %a{ href: "https://www.uniprot.org", target: "_blank" }
                         Uniprot
                       \.
                     %dt #Experiments:
@@ -120,10 +120,10 @@
           .col-md-4.col-md-offset-4
             %ul.list-inline
               %li
-                %a{ href: "http://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
+                %a{ href: "https://www.riken.jp/en/research/labs/ims/dis_sys_model/", target: "_blank" }
                   %img{ src: "/images/logo/riken-logo.gif", width: 100 }
               %li
-                %a{ href: "http://dbcls.rois.ac.jp", target: "_blank" }
+                %a{ href: "https://dbcls.rois.ac.jp", target: "_blank" }
                   %img{ src: "/images/logo/dbcls_logo.png", width: 100 }
         .row
           .col-md-6.col-md-offset-3


### PR DESCRIPTION
## Summary
- add EC2 launch and bootstrap scripts for a fresh wpgsa.org instance
- add a server inventory helper and maintenance plan
- clean up remaining http links in templates

## Notes
- defaults now target the master branch for new instance launches
- this follows the earlier HTTPS/layout fix already merged into master